### PR TITLE
Make native tests pass

### DIFF
--- a/src/test/kotlin/net/emteeware/NativeIndexPageTestIT.kt
+++ b/src/test/kotlin/net/emteeware/NativeIndexPageTestIT.kt
@@ -2,5 +2,11 @@ package net.emteeware
 
 import io.quarkus.test.junit.NativeImageTest
 
+// How to run
+/* Running this test from the IDE might fail on Windows as building the native application might fail.
+Build the native app manually as described here:  https://quarkus.io/guides/building-native-image
+Provide the necessary application properties as environment variables, e. g. via a run configuration.
+ */
+
 @NativeImageTest
 class NativeIndexPageTestIT : IndexPageTest()

--- a/src/test/kotlin/net/emteeware/NativeSelectionResourceIT.kt
+++ b/src/test/kotlin/net/emteeware/NativeSelectionResourceIT.kt
@@ -1,6 +1,0 @@
-package net.emteeware
-
-import io.quarkus.test.junit.NativeImageTest
-
-@NativeImageTest
-class NativeSelectionResourceIT : SelectionResourceTest()


### PR DESCRIPTION
One test has been removed as the unit test uses injection, which is not supported in native tests.
The other test is a little difficult to run, so a how to has been added as a commen.